### PR TITLE
Add english and german translations

### DIFF
--- a/src/Resources/contao/languages/de/default.xlf
+++ b/src/Resources/contao/languages/de/default.xlf
@@ -1,0 +1,77 @@
+<?xml version="1.0" ?><xliff version="1.1">
+  <file datatype="php" original="system/modules/isotopecartbackend/languages/en/default.php" source-language="en" target-language="fr">
+    <body>
+      <trans-unit id="ICBE.LBL.sku">
+        <source>SKU</source>
+        <target>SKU</target>
+      </trans-unit>
+      <trans-unit id="ICBE.LBL.product">
+        <source>Product</source>
+        <target>Produkt</target>
+      </trans-unit>
+      <trans-unit id="ICBE.LBL.quantity">
+        <source>Qty</source>
+        <target>Stk.</target>
+      </trans-unit>
+      <trans-unit id="ICBE.LBL.priceGross">
+        <source>Price (gross)</source>
+        <target>Preis brutto</target>
+      </trans-unit>
+      <trans-unit id="ICBE.LBL.priceNetto">
+        <source>Price (netto)</source>
+        <target>Preis netto</target>
+      </trans-unit>
+      <trans-unit id="ICBE.BTN.showDetails">
+        <source>Show details</source>
+        <target>Details anzeigen</target>
+      </trans-unit>
+      <trans-unit id="ICBE.BTN.hideDetails">
+        <source>Hide details</source>
+        <target>Details verbergen</target>
+      </trans-unit>
+
+      <trans-unit id="ICBE.LBL.cartItems">
+        <source>Items in cart</source>
+        <target>Produkte im Warenkorb</target>
+      </trans-unit>
+      <trans-unit id="ICBE.LBL.checkoutInfo">
+        <source>Checkout informations</source>
+        <target>Checkout-Informationen</target>
+      </trans-unit>
+      <trans-unit id="ICBE.LBL.cartEmpty">
+        <source>Cart is empty</source>
+        <target>Warenkorb ist leer</target>
+      </trans-unit>
+      <trans-unit id="ICBE.LBL.checkoutInfoNotAvailable">
+        <source>No checkout informations available</source>
+        <target>Keine Informationen zum Checkout verfügbar</target>
+      </trans-unit>
+
+      <trans-unit id="ICBE.LBL.cartStep.websiteSurfing">
+        <source>Website surfing</source>
+        <target>Website surfen</target>
+      </trans-unit>
+      <trans-unit id="ICBE.LBL.cartStep.paying">
+        <source>Paying</source>
+        <target>Bezahlen</target>
+      </trans-unit>
+      <trans-unit id="ICBE.LBL.cartStep.checkoutInfo">
+        <source>Checkout info</source>
+        <target>Checkout-Infos</target>
+      </trans-unit>
+      <trans-unit id="ICBE.LBL.cartStep.paymentMethodSelection">
+        <source>Payment method selection</source>
+        <target>Auswahl Zahlungsart</target>
+      </trans-unit>
+      <trans-unit id="ICBE.LBL.cartStep.shipmentMethodSelection">
+        <source>Shipment method selection</source>
+        <target>Auswahl Versandart</target>
+      </trans-unit>
+      <trans-unit id="ICBE.LBL.cartStep.addressFilling">
+        <source>Address filling</source>
+        <target>Adressangaben</target>
+      </trans-unit>
+
+    </body>
+  </file>
+</xliff>

--- a/src/Resources/contao/languages/de/default.xlf
+++ b/src/Resources/contao/languages/de/default.xlf
@@ -1,5 +1,5 @@
 <?xml version="1.0" ?><xliff version="1.1">
-  <file datatype="php" original="system/modules/isotopecartbackend/languages/en/default.php" source-language="en" target-language="fr">
+  <file datatype="php" original="system/modules/isotopecartbackend/languages/en/default.php" source-language="en" target-language="de">
     <body>
       <trans-unit id="ICBE.LBL.sku">
         <source>SKU</source>

--- a/src/Resources/contao/languages/de/modules.xlf
+++ b/src/Resources/contao/languages/de/modules.xlf
@@ -1,5 +1,5 @@
 <?xml version="1.0" ?><xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.1" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 http://docs.oasis-open.org/xliff/v1.2/cs02/xliff-core-1.2-strict.xsd">
-  <file datatype="plaintext" original="system/modules/isotope/languages/en/modules.xlf" source-language="en" target-language="fr">
+  <file datatype="plaintext" original="system/modules/isotope/languages/en/modules.xlf" source-language="en" target-language="de">
     <body>
       <trans-unit id="MOD.iso_carts.0">
         <source>Carts</source>

--- a/src/Resources/contao/languages/de/modules.xlf
+++ b/src/Resources/contao/languages/de/modules.xlf
@@ -1,0 +1,14 @@
+<?xml version="1.0" ?><xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.1" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 http://docs.oasis-open.org/xliff/v1.2/cs02/xliff-core-1.2-strict.xsd">
+  <file datatype="plaintext" original="system/modules/isotope/languages/en/modules.xlf" source-language="en" target-language="fr">
+    <body>
+      <trans-unit id="MOD.iso_carts.0">
+        <source>Carts</source>
+        <target>Warenkörbe</target>
+      </trans-unit>
+      <trans-unit id="MOD.iso_carts.1">
+        <source>See and manage carts for your shop</source>
+        <target>Warenkörbe für Ihren Shop anzeigen und verwalten</target>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Resources/contao/languages/de/tl_iso_product_collection.xlf
+++ b/src/Resources/contao/languages/de/tl_iso_product_collection.xlf
@@ -1,0 +1,18 @@
+<?xml version="1.0" ?><xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.1" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 http://docs.oasis-open.org/xliff/v1.2/cs02/xliff-core-1.2-strict.xsd">
+  <file datatype="plaintext" original="system/modules/isotope/languages/en/tl_iso_product_collection.xlf" source-language="en" target-language="fr">
+    <body>
+      <trans-unit id="tl_iso_product_collection.cart_last_action.0">
+        <source>Last action on</source>
+        <target>Letzte Aktion am</target>
+      </trans-unit>
+      <trans-unit id="tl_iso_product_collection.cart_current_step.0">
+        <source>Current step</source>
+        <target>Schritt</target>
+      </trans-unit>
+      <trans-unit id="tl_iso_product_collection.cart_actions.0">
+        <source></source>
+        <target></target>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Resources/contao/languages/de/tl_iso_product_collection.xlf
+++ b/src/Resources/contao/languages/de/tl_iso_product_collection.xlf
@@ -1,5 +1,5 @@
 <?xml version="1.0" ?><xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.1" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 http://docs.oasis-open.org/xliff/v1.2/cs02/xliff-core-1.2-strict.xsd">
-  <file datatype="plaintext" original="system/modules/isotope/languages/en/tl_iso_product_collection.xlf" source-language="en" target-language="fr">
+  <file datatype="plaintext" original="system/modules/isotope/languages/en/tl_iso_product_collection.xlf" source-language="en" target-language="de">
     <body>
       <trans-unit id="tl_iso_product_collection.cart_last_action.0">
         <source>Last action on</source>

--- a/src/Resources/contao/languages/en/default.xlf
+++ b/src/Resources/contao/languages/en/default.xlf
@@ -1,0 +1,57 @@
+<?xml version="1.0" ?><xliff version="1.1">
+  <file datatype="php" original="system/modules/isotopecartbackend/languages/en/default.php" source-language="en">
+    <body>
+      <trans-unit id="ICBE.LBL.sku">
+        <source>SKU</source>
+      </trans-unit>
+      <trans-unit id="ICBE.LBL.product">
+        <source>Product</source>
+      </trans-unit>
+      <trans-unit id="ICBE.LBL.quantity">
+        <source>Qty</source>
+      </trans-unit>
+      <trans-unit id="ICBE.LBL.priceGross">
+        <source>Price (gross)</source>
+      </trans-unit>
+      <trans-unit id="ICBE.LBL.priceNetto">
+        <source>Price (netto)</source>
+      </trans-unit>
+      <trans-unit id="ICBE.BTN.showDetails">
+        <source>Show details</source>
+      </trans-unit>
+      <trans-unit id="ICBE.BTN.hideDetails">
+        <source>Hide details</source>
+      </trans-unit>
+      <trans-unit id="ICBE.LBL.cartItems">
+        <source>Items in cart</source>
+      </trans-unit>
+      <trans-unit id="ICBE.LBL.checkoutInfo">
+        <source>Checkout informations</source>
+      </trans-unit>
+      <trans-unit id="ICBE.LBL.cartEmpty">
+        <source>Cart is empty</source>
+      </trans-unit>
+      <trans-unit id="ICBE.LBL.checkoutInfoNotAvailable">
+        <source>No checkout informations available</source>
+      </trans-unit>
+      <trans-unit id="ICBE.LBL.cartStep.websiteSurfing">
+        <source>Website surfing</source>
+      </trans-unit>
+      <trans-unit id="ICBE.LBL.cartStep.paying">
+        <source>Paying</source>
+      </trans-unit>
+      <trans-unit id="ICBE.LBL.cartStep.checkoutInfo">
+        <source>Checkout info</source>
+      </trans-unit>
+      <trans-unit id="ICBE.LBL.cartStep.paymentMethodSelection">
+        <source>Payment method selection</source>
+      </trans-unit>
+      <trans-unit id="ICBE.LBL.cartStep.shipmentMethodSelection">
+        <source>Shipment method selection</source>
+      </trans-unit>
+      <trans-unit id="ICBE.LBL.cartStep.addressFilling">
+        <source>Address filling</source>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Resources/contao/languages/en/modules.xlf
+++ b/src/Resources/contao/languages/en/modules.xlf
@@ -1,0 +1,12 @@
+<?xml version="1.0" ?><xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.1" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 http://docs.oasis-open.org/xliff/v1.2/cs02/xliff-core-1.2-strict.xsd">
+  <file datatype="plaintext" original="system/modules/isotope/languages/en/modules.xlf" source-language="en">
+    <body>
+      <trans-unit id="MOD.iso_carts.0">
+        <source>Carts</source>
+      </trans-unit>
+      <trans-unit id="MOD.iso_carts.1">
+        <source>See and manage carts for your shop</source>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Resources/contao/languages/en/tl_iso_product_collection.xlf
+++ b/src/Resources/contao/languages/en/tl_iso_product_collection.xlf
@@ -1,0 +1,15 @@
+<?xml version="1.0" ?><xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.1" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 http://docs.oasis-open.org/xliff/v1.2/cs02/xliff-core-1.2-strict.xsd">
+  <file datatype="plaintext" original="system/modules/isotope/languages/en/tl_iso_product_collection.xlf" source-language="en">
+    <body>
+      <trans-unit id="tl_iso_product_collection.cart_last_action.0">
+        <source>Last action on</source>
+      </trans-unit>
+      <trans-unit id="tl_iso_product_collection.cart_current_step.0">
+        <source>Current step</source>
+      </trans-unit>
+      <trans-unit id="tl_iso_product_collection.cart_actions.0">
+        <source></source>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>


### PR DESCRIPTION
English translations are mandatory because English is used as a fallback. If no English translations are available and the currently used language is for example German the following exception will be thrown.
The German translations are of course not necessary, I just thought I'd add them when I'm at it. 🙂 

```
ErrorException:
Warning: Undefined array key "ICBE"

  at vendor/webexmachina/contao-isotope-cart-backend-bundle/src/DataContainer/IsoProductCollectionContainer.php:112
  at IsotopeCartBackendBundle\DataContainer\IsoProductCollectionContainer->getCartLabel(...)
     (vendor/contao/core-bundle/src/Resources/contao/classes/DataContainer.php:1820)
  at Contao\DataContainer->generateRecordLabel(array(...)
     (vendor/contao/core-bundle/src/Resources/contao/drivers/DC_Table.php:5064)
  at Contao\DC_Table->listView()
     (vendor/contao/core-bundle/src/Resources/contao/drivers/DC_Table.php:313)
  at Contao\DC_Table->showAll()
     (vendor/contao/core-bundle/src/Resources/contao/classes/Backend.php:667)
  at Contao\Backend->getBackendModule('iso_carts', null)
     (vendor/contao/core-bundle/src/Resources/contao/controllers/BackendMain.php:168)
  at Contao\BackendMain->run()
     (vendor/contao/core-bundle/src/Controller/BackendController.php:49)
  at Contao\CoreBundle\Controller\BackendController->mainAction()
     (vendor/symfony/http-kernel/HttpKernel.php:163)
  at Symfony\Component\HttpKernel\HttpKernel->handleRaw(object(Request), 1)
     (vendor/symfony/http-kernel/HttpKernel.php:75)
  at Symfony\Component\HttpKernel\HttpKernel->handle(object(Request), 1, true)
     (vendor/symfony/http-kernel/Kernel.php:202)
  at Symfony\Component\HttpKernel\Kernel->handle(object(Request))
     (public/index.php:44)                
 ```