### PR TITLE
Check member field against 0 instead of null

### DIFF
--- a/src/DataContainer/IsoProductCollectionContainer.php
+++ b/src/DataContainer/IsoProductCollectionContainer.php
@@ -84,7 +84,7 @@ class IsoProductCollectionContainer
                     break;
 
                 case 'member':
-                    if (null === $row['member']) {
+                    if (0 === $row['member']) {
                         $args[$i] = '-';
                         break;
                     }


### PR DESCRIPTION
`tl_iso_product_collection.member` is not nullable, so this check will never be true. A guest cart has `0` set in the member field.

Reference: https://github.com/isotope/core/blob/2.9/system/modules/isotope/dca/tl_iso_product_collection.php#L152